### PR TITLE
Feature: Additional Allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ This can be caused from any of the following: Wrong location, not enough disk sp
 The customer gets an email from the panel to setup their account (incl. password) if they didn't have an account before. Otherwise they should be able to use their existing credentials.
 
 ## My game requires multiple ports allocated.
-Currently, this isn't possible with this module but is planned.
+Configure the "Additional Ports" option in the module settings.
+It expects a comma-separated list of ports as a numeric offset from the first available allocation.
+E.g: If you enter `1,2,4` and the first available port happens to be 25565, you'll get as additional allocations: (If they're available) 
+* 25566 (First Port + 1)
+* 25567 (First Port +2)
+* 25569 (First Port +4)
 
 ## How to enable module debug log
 1. In WHMCS 7 or below navigate to Utilities > Logs > Module Log. For WHMCS 8.x navigate to System Logs > Module Log in the left sidebar.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Please use the [WISP Discord](https://wisp.gg/discord) for configuration related
 ## Credits
 [Dane](https://github.com/DaneEveritt) and [everyone else](https://github.com/Pterodactyl/Panel/graphs/contributors) involved in development of the Pterodactyl Panel.  
 [death-droid](https://github.com/death-droid) for the original WHMCS module.  
+[snags141](https://github.com/snags141/) for additional allocation support.
 
 # FAQ
 
@@ -40,7 +41,7 @@ Valid options: ``server_name, memory, swap, io, cpu, disk, nest_id, egg_id, pack
 This also works for any name of environment variable:  
 Player Slots => Will overwrite the environment variable named "Player Slots" to its value.  
 
-Useful trick: You can use the | seperator to change the display name of the variable like this:  
+Useful trick: You can use the | separator to change the display name of the variable like this:  
 dedicated_ip|Dedicated IP => Will be displayed as "Dedicated IP" but will work correctly.  
 
 [Sample configuration for configurable memory](https://owo.whats-th.is/85JwhVX.png)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ E.g: If you enter `1,2,4` and the first available port happens to be 25565, you'
 * 25567 (First Port +2)
 * 25569 (First Port +4)
 
+Note: Currently if this option is set, will override anything specified under "port_range" - Use one or the other.
+
 You'll also want to configure "Additional Port Failure Mode".
 This determines what the module should do if there are no allocations available on any of the defined nodes.
 * "Continue" - Continues creating the server but only with one allocation, whatever is available at the time. You'll need to manually go in after the server gets created to assign additional ports as required.

--- a/README.md
+++ b/README.md
@@ -53,19 +53,34 @@ This can be caused from any of the following: Wrong location, not enough disk sp
 The customer gets an email from the panel to setup their account (incl. password) if they didn't have an account before. Otherwise they should be able to use their existing credentials.
 
 ## My game requires multiple ports allocated.
-Configure the "Additional Ports" option in the module settings.
-It expects a comma-separated list of ports as a numeric offset from the first available allocation.
-E.g: If you enter `1,2,4` and the first available port happens to be 25565, you'll get as additional allocations: (If they're available) 
+Configure the "**Additional Ports**" option in the module settings.
+It expects a valid JSON string consisting of the parameter name or NONE, and a number representing a port as a numeric offset from the first available allocation.
+E.g: If you enter `{"NONE":1, "NONE":2, "NONE":4}` and the first available port happens to be 25565, you'll get as additional allocations: 
 * 25566 (First Port + 1)
 * 25567 (First Port +2)
 * 25569 (First Port +4)
 
-Note: Currently if this option is set, will override anything specified under "port_range" - Use one or the other.
+(If they're available)
 
-You'll also want to configure "Additional Port Failure Mode".
+Note: I this option is set, it will override anything specified under "port_range" - Use one or the other, not both.
+
+You'll also want to configure "**Additional Port Failure Mode**".
 This determines what the module should do if there are no allocations available on any of the defined nodes.
 * "Continue" - Continues creating the server but only with one allocation, whatever is available at the time. You'll need to manually go in after the server gets created to assign additional ports as required.
 * "Stop" - Stops the server creation and raises an error.
+
+## How to assign additional allocations to server parameters like RCON_PORT
+See the table below for "Additional Ports" example values.
+*These examples assume your WISP node has allocations available from 1000-2000.*
+
+| Game | Required Ports  |Additional Ports Example  | Ports Assigned  |
+| ------------ | ------------ | ------------ |
+| Rust | Game port and RCON port | `{"RCON_PORT":1}`  | Game Port: 1000, RCON_PORT: 1001|
+| Arma 3 | Game port, Game port +1 for Steam Query, Game port + 2 for Steam Port, and Game port +4 for BattleEye |  `{"NONE":1, "NONE":2, "NONE":4}` | Game Port: 1000, Additional Ports: 1001, 1002, 1004 |
+| Unturned | Game port, Game port +1 and Game port +2 | `{"NONE":1, "NONE":2}` | Game Port: 1000, Additional Ports: 1001, 1002 |
+| Project Zomboid | Game Port, Steam port and an additional port for every player. Let's say we want 10 additional ports for 10 players. | `{"STEAM_PORT": 1, "NONE": 2, "NONE": 3, "NONE": 4, "NONE": 5, "NONE": 6, "NONE": 7, "NONE": 8, "NONE": 9, "NONE": 10, "NONE":11}` | Game Port: 1000, Steam Port: 1001, Additional Ports: 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011|
+**What does "NONE" mean?**
+"NONE" means you want to assign the additional port to the server, but it doesn't need to be assigned to a server parameter. If instead you want to add a +1 allocation and assign it to the parameter "RCON_PORT then you'd use `{"RCON_PORT":1}` for example.
 
 ## How to enable module debug log
 1. In WHMCS 7 or below navigate to Utilities > Logs > Module Log. For WHMCS 8.x navigate to System Logs > Module Log in the left sidebar.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please use the [WISP Discord](https://wisp.gg/discord) for configuration related
 
 1. Download/Git clone this repository.  
 2. Move the ``wisp/`` folder into ``<path to whmcs>/modules/servers/``.
-3. Create API Credentials with these permissions: ![Image](https://owo.whats-th.is/fa1eee.png)
+3. Create API Credentials with these permissions: ![Image](https://i.imgur.com/nzo0u8C.png)
 4. In WHMCS navigate to Setup > Products/Services > Servers
 5. Create new server, fill the name with anything you want, hostname as the url to the panel. For example: ``my-panel.panel.gg``
 6. Change Server Type to WISP, leave username empty, fill the password field with your generated API Key.
@@ -58,6 +58,11 @@ E.g: If you enter `1,2,4` and the first available port happens to be 25565, you'
 * 25566 (First Port + 1)
 * 25567 (First Port +2)
 * 25569 (First Port +4)
+
+You'll also want to configure "Additional Port Failure Mode".
+This determines what the module should do if there are no allocations available on any of the defined nodes.
+* "Continue" - Continues creating the server but only with one allocation, whatever is available at the time. You'll need to manually go in after the server gets created to assign additional ports as required.
+* "Stop" - Stops the server creation and raises an error.
 
 ## How to enable module debug log
 1. In WHMCS 7 or below navigate to Utilities > Logs > Module Log. For WHMCS 8.x navigate to System Logs > Module Log in the left sidebar.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The customer gets an email from the panel to setup their account (incl. password
 ## My game requires multiple ports allocated.
 Configure the "**Additional Ports**" option in the module settings.
 It expects a valid JSON string consisting of the parameter name or NONE, and a number representing a port as a numeric offset from the first available allocation.
-E.g: If you enter `{"NONE":1, "NONE":2, "NONE":4}` and the first available port happens to be 25565, you'll get as additional allocations: 
+E.g: If you enter `{1:"NONE", 2:"NONE", 4:"NONE"}` and the first available port happens to be 25565, you'll get as additional allocations: 
 * 25566 (First Port + 1)
 * 25567 (First Port +2)
 * 25569 (First Port +4)
@@ -74,13 +74,14 @@ See the table below for "Additional Ports" example values.
 *These examples assume your WISP node has allocations available from 1000-2000.*
 
 | Game | Required Ports  |Additional Ports Example  | Ports Assigned  |
-| ------------ | ------------ | ------------ |
-| Rust | Game port and RCON port | `{"RCON_PORT":1}`  | Game Port: 1000, RCON_PORT: 1001|
-| Arma 3 | Game port, Game port +1 for Steam Query, Game port + 2 for Steam Port, and Game port +4 for BattleEye |  `{"NONE":1, "NONE":2, "NONE":4}` | Game Port: 1000, Additional Ports: 1001, 1002, 1004 |
-| Unturned | Game port, Game port +1 and Game port +2 | `{"NONE":1, "NONE":2}` | Game Port: 1000, Additional Ports: 1001, 1002 |
-| Project Zomboid | Game Port, Steam port and an additional port for every player. Let's say we want 10 additional ports for 10 players. | `{"STEAM_PORT": 1, "NONE": 2, "NONE": 3, "NONE": 4, "NONE": 5, "NONE": 6, "NONE": 7, "NONE": 8, "NONE": 9, "NONE": 10, "NONE":11}` | Game Port: 1000, Steam Port: 1001, Additional Ports: 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011|
+| ------------ | ------------ | ------------ | ------------ |
+| Rust | Game port and RCON port | `{1:"RCON_PORT"}`  | Game Port: 1000, RCON_PORT: 1001|
+| Arma 3 | Game port, Game port +1 for Steam Query, Game port + 2 for Steam Port, and Game port +4 for BattleEye |  `{1:"NONE", 2:"NONE", 4:"NONE"}` | Game Port: 1000, Additional Ports: 1001, 1002, 1004 |
+| Unturned | Game port, Game port +1 and Game port +2 | `{1:"NONE", 2:"NONE"}` | Game Port: 1000, Additional Ports: 1001, 1002 |
+| Project Zomboid | Game Port, Steam port and an additional port for every player. Let's say we want 10 additional ports for 10 players. | `{1:"STEAM_PORT", 2:"NONE", 3:"NONE", 4:"NONE", 5:"NONE", 6:"NONE", 7:"NONE", 8:"NONE", 9:"NONE", 10:"NONE", 11:"NONE"}` | Game Port: 1000, Steam Port: 1001, Additional Ports: 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011|
+
 **What does "NONE" mean?**
-"NONE" means you want to assign the additional port to the server, but it doesn't need to be assigned to a server parameter. If instead you want to add a +1 allocation and assign it to the parameter "RCON_PORT then you'd use `{"RCON_PORT":1}` for example.
+"NONE" means you want to assign the additional port to the server, but it doesn't need to be assigned to a server parameter. If instead you want to add a +1 port and assign it to the parameter "RCON_PORT" then you'd use `{1:"RCON_PORT"}` for example.
 
 ## How to enable module debug log
 1. In WHMCS 7 or below navigate to Utilities > Logs > Module Log. For WHMCS 8.x navigate to System Logs > Module Log in the left sidebar.

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -172,7 +172,7 @@ function wisp_ConfigOptions() {
         ],
         "additional_ports" => [
             "FriendlyName" => "Additional Ports",
-            "Description" => "Additional ports in a JSON string, each must have a key of either "NONE" or an egg parameter name to set. E.g. If you want a game port, game port+1 and RCON_PORT assigned to game port +4 then use: {\"NONE\":1, \"RCON_PORT\":4} (optional)",
+            "Description" => "Additional ports to assign to the server. See the module readme for instructions: <a href=\"https://github.com/wisp-gg/whmcs/\" target=\"_blank\">View Readme</a> (optional)",
             "Type" => "text",
             "Size" => 25,
         ],
@@ -183,7 +183,7 @@ function wisp_ConfigOptions() {
                 'continue' => 'Continue',
                 'stop' => 'Stop',
             ],
-            "Description" => "Determines whether server creation will continue if none of your nodes are able to satisfy the additional port allocation",
+            "Description" => "Determines whether server creation will continue if none of your nodes are able to satisfy the additional port allocation. See the module readme for more information: <a href=\"https://github.com/wisp-gg/whmcs/\" target=\"_blank\">View Readme</a>",
             "Default" => "continue",
         ],
         "startup" => [
@@ -437,7 +437,7 @@ function wisp_CreateAccount(array $params) {
                 }
                 if(!$alloc_success) {
                     // Failure handling logic
-                    if($additional_port_fail_mode = "Stop") {
+                    if($additional_port_fail_mode == "stop") {
                         throw new Exception('Couldn\'t find any nodes to satisfy the requested allocations.');
                     } else {
                         // Continue with normal deployment
@@ -782,21 +782,10 @@ function findFreePorts(array $available_allocations, string $port_offsets) {
         $ports_found                The array of ports that were found available, based on the offsets
                                     the additional ports required.
     */
-    // Iterate over available IP's
-
-    // Decode json string of port offsets
-    $none_string = "\"NONE\"";
-    $pos_idx = 1;
-    $pos = strpos($port_offsets, $none_string);
-    while($pos != false) {
-        // Rename any "NONE" keys as we can't decode duplicates
-        $port_offsets = substr_replace($port_offsets, "\"NONE_".$pos_idx."\"", $pos, strlen($none_string));
-        $pos = strpos($port_offsets, $none_string);
-        $pos_idx ++;
-    }
-
+    
     $port_offsets_array = json_decode($port_offsets, true);
 
+    // Iterate over available IP's
     foreach($available_allocations as $ip_addr => $ports) {
         $result = Array();
         $result['status'] = false;
@@ -827,7 +816,7 @@ function findFreePorts(array $available_allocations, string $port_offsets) {
             if($found_all == true) {
                 logModuleCall("WISP-WHMCS", "Found a game port allocation ID: ".$main_allocation_id, "", "");
                 logModuleCall("WISP-WHMCS", "Found additional allocation ID's: ".print_r($additional_allocation_ids, true), "", "");
-                logModuleCall("WISP-WHMCS", "Found additional allocation Keys: ".print_r($additional_allocation_keys, true), "", "");
+                logModuleCall("WISP-WHMCS", "Found additional allocation Ports: ".print_r($additional_allocation_ports, true), "", "");
                 $result['main_allocation_id'] = $main_allocation_id;
                 $result['main_allocation_port'] = $main_allocation_port;
                 $result['additional_allocation_ids'] = $additional_allocation_ids;

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -686,13 +686,11 @@ function getNodes(array $params, int $loc_id) {
     /*
         Fetches and returns all nodes with a specific location_id
     */
-    $filteredNodes = array();
+    $filteredNodes = Array();
     $nodes = wisp_API($params, 'nodes/');
     foreach($nodes['data'] as $key => $value) {
         $node_id = $value['attributes']['id'];
-        if(!isset($loc_id) || $value['attributes']['location_id'] == $loc_id) {
-            array_push($filteredNodes, $node_id);
-        } else {
+        if($value['attributes']['location_id'] == $loc_id) {
             array_push($filteredNodes, $node_id);
         }
     }

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -455,8 +455,6 @@ function wisp_CreateAccount(array $params) {
 
         // Create the game server
         $server = wisp_API($params, 'servers', $serverData, 'POST');
-        if($server['status_code'] === 400) throw new Exception('Couldn\'t find any nodes satisfying the request.');
-        if($server['status_code'] !== 201) throw new Exception('Failed to create the server, received the error code: ' . $server['status_code'] . '. Enable module debug log for more info.');
 
         // Catch API errors
         if($server['status_code'] === 400) throw new Exception('Couldn\'t find any nodes satisfying the request.');

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -172,7 +172,7 @@ function wisp_ConfigOptions() {
         ],
         "additional_ports" => [
             "FriendlyName" => "Additional Ports",
-            "Description" => "Additional ports as an offset from the first allocation - seperated by comma. Example: if the first assigned port is 25565 and you enter '1,2,4' then you'll get three additional ports 25565+1 (25566) 25565+2 (25567) and 25565+4 (25569). Note: Setting this will ignore the port_range setting. (optional)",
+            "Description" => "Additional ports in a JSON string, each must have a key of either "NONE" or an egg parameter name to set. E.g. If you want a game port, game port+1 and RCON_PORT assigned to game port +4 then use: {\"NONE\":1, \"RCON_PORT\":4} (optional)",
             "Type" => "text",
             "Size" => 25,
         ],
@@ -794,7 +794,7 @@ function findFreePorts(array $available_allocations, string $port_offsets) {
         $pos = strpos($port_offsets, $none_string);
         $pos_idx ++;
     }
-    
+
     $port_offsets_array = json_decode($port_offsets, true);
 
     foreach($available_allocations as $ip_addr => $ports) {

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -170,22 +170,6 @@ function wisp_ConfigOptions() {
             "Type" => "text",
             "Size" => 25,
         ],
-        "additional_ports" => [
-            "FriendlyName" => "Additional Ports",
-            "Description" => "Additional ports to assign to the server. See the module readme for instructions: <a href=\"https://github.com/wisp-gg/whmcs/\" target=\"_blank\">View Readme</a> (optional)",
-            "Type" => "text",
-            "Size" => 25,
-        ],
-        "additional_port_fail_mode" => [
-            "FriendlyName" => "Additional Port Failure Mode",
-            "Type" => "dropdown",
-            "Options" => [
-                'continue' => 'Continue',
-                'stop' => 'Stop',
-            ],
-            "Description" => "Determines whether server creation will continue if none of your nodes are able to satisfy the additional port allocation. See the module readme for more information: <a href=\"https://github.com/wisp-gg/whmcs/\" target=\"_blank\">View Readme</a>",
-            "Default" => "continue",
-        ],
         "startup" => [
             "FriendlyName" => "Startup",
             "Description" => "Custom startup command to assign to the created server (optional)",
@@ -220,6 +204,22 @@ function wisp_ConfigOptions() {
             "Description" => "Amount in megabytes the server can use for backups (optional)",
             "Type" => "text",
             "Size" => 25,
+        ],
+        "additional_ports" => [
+            "FriendlyName" => "Additional Ports",
+            "Description" => "Additional ports to assign to the server. See the module readme for instructions: <a href=\"https://github.com/wisp-gg/whmcs/\" target=\"_blank\">View Readme</a> (optional)",
+            "Type" => "text",
+            "Size" => 25,
+        ],
+        "additional_port_fail_mode" => [
+            "FriendlyName" => "Additional Port Failure Mode",
+            "Type" => "dropdown",
+            "Options" => [
+                'continue' => 'Continue',
+                'stop' => 'Stop',
+            ],
+            "Description" => "Determines whether server creation will continue if none of your nodes are able to satisfy the additional port allocation. See the module readme for more information: <a href=\"https://github.com/wisp-gg/whmcs/\" target=\"_blank\">View Readme</a>",
+            "Default" => "continue",
         ],
     ];
 }

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -423,6 +423,20 @@ function wisp_CreateAccount(array $params) {
                         
                         $serverData['allocation']['default'] = intval($final_allocations['main_allocation_id']);
                         $serverData['allocation']['additional'] = $final_allocations['additional_allocation_ids'];
+
+                        // Update the start command - game port
+                        logActivity("Starting to update command: ".$startup);
+                        $startup = str_replace("{{game_port}}", $final_allocations['main_allocation_port'], $startup);
+                        logActivity("Replacing game_port with ". $final_allocations['main_allocation_port']);
+                        $idx = 1;
+                        // Update the start command - additional allocations
+                        foreach($final_allocations['additional_allocation_ports'] as $key => $port) {
+                            logActivity("Replacing additional_port_".$idx." with ". $port);
+                            $startup = str_replace("{{additional_port_".$idx."}}", $port, $startup);
+                            $idx++;
+                        }
+                        logActivity("The final startup command is: " . $startup);
+                        $serverData['startup'] = $startup;
                         // We successfully found an available allocation, break and check no more nodes.
                         break;
                     }
@@ -788,7 +802,7 @@ function findFreePorts(array $available_allocations, array $port_offsets) {
         logActivity("Checking IP: ".$ip_addr);
         foreach($ports as $port => $portDetails) {
             $main_allocation_id = $portDetails['id'];
-            $mail_allocation_port = $port;
+            $main_allocation_port = $port;
             $found_all = true;
             foreach($port_offsets as $key => $port_offset) {
                 $next_port = intval($port) + intval($port_offset);
@@ -805,7 +819,7 @@ function findFreePorts(array $available_allocations, array $port_offsets) {
                 logActivity("Main port allocation ID: ". $main_allocation_id);
                 logActivity("Additional port allocation ID's: ". print_r($additional_allocation_ids, true));
                 $result['main_allocation_id'] = $main_allocation_id;
-                $result['main_allocatiion_port'] = $mail_allocation_port;
+                $result['main_allocation_port'] = $main_allocation_port;
                 $result['additional_allocation_ids'] = $additional_allocation_ids;
                 $result['status'] = true;
                 return $result;
@@ -820,3 +834,4 @@ function findFreePorts(array $available_allocations, array $port_offsets) {
         return false;
     }
 }
+

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -434,8 +434,9 @@ function wisp_CreateAccount(array $params) {
         
         $patchData = [
             'add_allocations' => $final_allocations['additional_allocation_ids'],
-        ]
+        ];
         logActivity("Adding additional allocations to server. ");
+        $serverId = wisp_GetServerID($params);
         $server = wisp_API($params, 'servers/' . $serverId . "/build", $patchData, 'PATCH');
     }
     

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -172,7 +172,7 @@ function wisp_ConfigOptions() {
         ],
         "additional_ports" => [
             "FriendlyName" => "Additional Ports",
-            "Description" => "Additional ports as an offset from the first allocation - seperated by comma. Example: if the first assigned port is 25565 and you enter '1,2,4' then you'll get three additional ports 25565+1 (25566) 25565+2 (25567) and 25565+4 (25569). Note: Setting this will overwrite the port_range setting. (optional)",
+            "Description" => "Additional ports as an offset from the first allocation - seperated by comma. Example: if the first assigned port is 25565 and you enter '1,2,4' then you'll get three additional ports 25565+1 (25566) 25565+2 (25567) and 25565+4 (25569). Note: Setting this will ignore the port_range setting. (optional)",
             "Type" => "text",
             "Size" => 25,
         ],

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -290,7 +290,6 @@ function wisp_GetOption(array $params, $id, $default = NULL) {
 }
 
 function wisp_CreateAccount(array $params) {
-    logActivity('Doing wisp_CreateAccount');
     try {
         // Checking if the server ID already exists
         $serverId = wisp_GetServerID($params);
@@ -672,7 +671,6 @@ function wisp_ClientArea(array $params) {
     }
 }
 
-
 /* Utility Functions */
 function getNodes(array $params, int $loc_id) {
     /*
@@ -709,11 +707,10 @@ function getAllocations(array $params, int $node_id){
             ['192.168.1.123'] => {
                 ['1234'] => {
                     ['id'] = 1234;
-                }
+                }z
             },
         ]
     */
-    echo "Getting Allocations \n";
     $available_allocations = array();
     $allocations = getPaginatedData($params,'nodes/'.$node_id.'/allocations');
     foreach($allocations as $key => $allocation) {


### PR DESCRIPTION
### Changed:
- Modified the server creation logic (wisp_CreateAccount) to check if the additional allocations field has been set. If it has, fetches all allocations from each applicable node.
- Updated Readme instructions, in particular the FAQ section regarding additional allocations and the API permissions image to include read access to allocations.

### Added:
- Comments to code to help improve readability for someone picking it up for the first time
- Log messages that are optionally turned on in your WHMCS settings. This should help troubleshoot issues when starting to use this module.
- additional_ports parameter (optional) -> Allows specifying additional allocations based on an offset of the first available allocation. **Allocation assignment logic explained below**
- additional_port_fail_mode (optional) -> Specifies what action the module should take if it fails to find nodes with allocations available (e.g. allocations are either full or so full and fragmented such that it can't facilitate the required offsets). Continue = Create the server anyways, but only with one allocation, whatever is available. Stop = Raise an exception and stop the server from being created.

### Allocation Assignment Logic
(Assuming the optional additional allocations parameter has been set, otherwise continues as normal)
1. Pull a list of nodes based on the location ID
2. For each node, pull all allocations
3. Filter available allocations into an array of ports by each IP address
4. Check for a port that matches base port and base port+ [each additional allocation offset]
5. If found available allocations that meet requirements, return and create the server as normal (If any environment parameters are mapped to an allocation like RCON_PORT we assign those before creating the server)
6. If not, continue based on fail mode

### Other Notes
The only minor thing to be aware of is the logic I've implemented pays no attention to the optional field "port_range". 
If "additional_ports" is set, it'll just find any ports available that meet your requirements, ignoring any specified port range in the "port_range" parameter.
It's possible to change this in future, but I didn't see this as being an issue and using both parameters together seems to be a rare use-case.

More than happy to hear any feedback or suggestions to improve this before merge 👍 
Cheers all!