### PR TITLE
Allow account creation for nameless users

### DIFF
--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -286,7 +286,7 @@ function wisp_CreateAccount(array $params) {
                     'email' => $params['clientsdetails']['email'],
                     //set first_name and last_name if empty
                     'first_name' => empty($params['clientsdetails']['firstname']) ? 'Unkown' : $params['clientsdetails']['firstname'],
-                    'last_name' =>empty($params['clientsdetails']['lastname']) ? 'User' : $params['clientsdetails']['lastname'],
+                    'last_name' => empty($params['clientsdetails']['lastname']) ? 'User' : $params['clientsdetails']['lastname'],
                     'external_id' => $params['clientsdetails']['uuid'],
                 ], 'POST');
             } else {

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -284,8 +284,7 @@ function wisp_CreateAccount(array $params) {
             if($userResult['meta']['pagination']['total'] === 0) {
                 $userResult = wisp_API($params, 'users', [
                     'email' => $params['clientsdetails']['email'],
-                    //set first_name and last_name if empty
-                    'first_name' => empty($params['clientsdetails']['firstname']) ? 'Unkown' : $params['clientsdetails']['firstname'],
+                    'first_name' => empty($params['clientsdetails']['firstname']) ? 'Unknown' : $params['clientsdetails']['firstname'],
                     'last_name' => empty($params['clientsdetails']['lastname']) ? 'User' : $params['clientsdetails']['lastname'],
                     'external_id' => $params['clientsdetails']['uuid'],
                 ], 'POST');

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -284,8 +284,9 @@ function wisp_CreateAccount(array $params) {
             if($userResult['meta']['pagination']['total'] === 0) {
                 $userResult = wisp_API($params, 'users', [
                     'email' => $params['clientsdetails']['email'],
-                    'first_name' => $params['clientsdetails']['firstname'],
-                    'last_name' => $params['clientsdetails']['lastname'],
+                    //set first_name and last_name if empty
+                    'first_name' => empty($params['clientsdetails']['firstname']) ? 'Unkown' : $params['clientsdetails']['firstname'],
+                    'last_name' =>empty($params['clientsdetails']['lastname']) ? 'User' : $params['clientsdetails']['lastname'],
                     'external_id' => $params['clientsdetails']['uuid'],
                 ], 'POST');
             } else {


### PR DESCRIPTION
Since whmcs allows you to make both last and first name optional (although I don't know why someone would want that), this module should use a mechanism to prevent these fields to be empty.

This PR will use a hardcoded username if the either firstname or lastname is empty.

I might also add support a "client_firstname" and "client_lastname" as configurable options